### PR TITLE
Correcao de URL - Eksctl

### DIFF
--- a/4 - AWS EKS/Comandos_Lab_01.txt
+++ b/4 - AWS EKS/Comandos_Lab_01.txt
@@ -17,7 +17,8 @@ kubectl completion bash >>  ~/.bash_completion
 
 # Passo 4 - Instalar o eksctl na instância Cloud9:
 
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+#curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv -v /tmp/eksctl /usr/local/bin
 
 

--- a/4 - AWS EKS/Comandos_Lab_02.txt
+++ b/4 - AWS EKS/Comandos_Lab_02.txt
@@ -2,6 +2,9 @@
 
 eksctl create cluster -f ./eks_cluster.yaml
 
+#Atualizar o Cluster
+eksctl update cluster -f ./eks_cluster.yaml --approve
+
 # Passo 2 - Inspecionar o cluster EKS criado
 
 eksctl get cluster --region=us-east-1

--- a/9 - Monitoramento e Observabilidade/Comandos_Lab_16.txt
+++ b/9 - Monitoramento e Observabilidade/Comandos_Lab_16.txt
@@ -12,7 +12,7 @@ kubectl apply -f ./3-Grafana
 
 # Passo 4 - Criar os dashboards no Grafana a partir do arquivo yaml:
 
-kubectl apply -f ./3-Grafana_Dashboards
+kubectl apply -f ./4-Grafana_Dashboards
 
 # Passo 5 - Acessar o dashboard Grafana a partir do endpoint alocado pelo serviço:
 


### PR DESCRIPTION
URL do eksctl mudou de:
https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz"

para:
https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"